### PR TITLE
Correct OTA platform

### DIFF
--- a/tx_ultimate.yaml
+++ b/tx_ultimate.yaml
@@ -119,6 +119,7 @@ dashboard_import:
 api:
 
 ota:
+ - platform: esphome
 
 wifi:
   ap:

--- a/tx_ultimate_2x_cover_us.yaml
+++ b/tx_ultimate_2x_cover_us.yaml
@@ -169,6 +169,7 @@ dashboard_import:
 api:
 
 ota:
+ - platform: esphome
 
 wifi:
   ap:

--- a/tx_ultimate_cover.yaml
+++ b/tx_ultimate_cover.yaml
@@ -157,6 +157,7 @@ dashboard_import:
 api:
 
 ota:
+ - platform: esphome
 
 wifi:
   ap:

--- a/tx_ultimate_cover_and_2x_switches_us.yaml
+++ b/tx_ultimate_cover_and_2x_switches_us.yaml
@@ -157,6 +157,7 @@ dashboard_import:
 api:
 
 ota:
+ - platform: esphome
 
 wifi:
   ap:

--- a/tx_ultimate_cover_us.yaml
+++ b/tx_ultimate_cover_us.yaml
@@ -157,6 +157,7 @@ dashboard_import:
 api:
 
 ota:
+ - platform: esphome
 
 wifi:
   ap:

--- a/tx_ultimate_local.yaml
+++ b/tx_ultimate_local.yaml
@@ -112,7 +112,9 @@ logger:
     uart_debug: INFO
 
 api:
+
 ota:
+ - platform: esphome
 
 wifi:
   ssid: !secret wifi_ssid

--- a/tx_ultimate_local_us.yaml
+++ b/tx_ultimate_local_us.yaml
@@ -114,6 +114,7 @@ logger:
 api:
 
 ota:
+ - platform: esphome
 
 wifi:
   ap:

--- a/tx_ultimate_us.yaml
+++ b/tx_ultimate_us.yaml
@@ -118,6 +118,7 @@ dashboard_import:
 api:
 
 ota:
+ - platform: esphome
 
 wifi:
   ap:
@@ -134,8 +135,6 @@ external_components:
       url: https://github.com/SmartHome-yourself/sonoff-tx-ultimate-for-esphome
       ref: main
     components: [tx_ultimate_touch]
-    
-
 
 globals:
   - id: nightlight_color


### PR DESCRIPTION
Since ESPHOME 2024.6.0 OTA platform change to this way:

```
ota:
 - platform: esphome
```

I've correct in my local config and this works fine.