### PR TITLE
fix: replace empty effect names with 'none' for ESPHome 2026.3.0 compatibility

### DIFF
--- a/tx_ultimate.yaml
+++ b/tx_ultimate.yaml
@@ -27,7 +27,7 @@ substitutions:
 
   long_press_brightness: "1"
   long_press_color: "{100,0,0}"
-  long_press_effect: ""
+  long_press_effect: "none"
 
   multi_touch_brightness: "1"
   multi_touch_color: "{0,0,0}"
@@ -35,11 +35,11 @@ substitutions:
 
   swipe_left_brightness: "1"
   swipe_left_color: "{0,100,0}"
-  swipe_left_effect: ""
+  swipe_left_effect: "none"
 
   swipe_right_brightness: "1"
   swipe_right_color: "{100,0,70}"
-  swipe_right_effect: ""
+  swipe_right_effect: "none"
 
   relay_1_pin: GPIO18
   relay_2_pin: GPIO17


### PR DESCRIPTION
## Problem

ESPHome 2026.3.0 introduced a breaking change where empty string effect names (`""`) are no longer valid. This causes compilation to fail with:

```
Effect '' not found in light 'leds_top'
```

See issue #83 for details.

## Fix

Replace the empty default values for `long_press_effect`, `swipe_left_effect` and `swipe_right_effect` with `"none"`, which is the correct way to specify no effect in ESPHome 2026.3.0+.

## Changes

```yaml
# Before
long_press_effect: ""
swipe_left_effect: ""
swipe_right_effect: ""

# After
long_press_effect: "none"
swipe_left_effect: "none"
swipe_right_effect: "none"
```

Fixes #83